### PR TITLE
chore: use structured errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,23 +4,17 @@
 name = "acme2"
 version = "0.2.0"
 dependencies = [
- "anyhow",
  "base64",
  "hyper",
  "openssl",
  "reqwest",
  "serde",
  "serde_json",
+ "thiserror",
  "tokio",
  "tracing",
  "tracing-futures",
 ]
-
-[[package]]
-name = "anyhow"
-version = "1.0.38"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afddf7f520a80dbf76e6f50a35bca42a2331ef227a28b3b6dc5c2e2338d114b1"
 
 [[package]]
 name = "autocfg"
@@ -680,6 +674,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0f4a65597094d4483ddaed134f409b2cb7c1beccf25201a9f73c719254fa98e"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7765189610d8241a44529806d6fd1f2e0a08734313a35d5b3a556f92b381f3c0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ repository = "https://github.com/lucacasonato/acme2"
 edition = "2018"
 
 [dependencies]
-anyhow = "1.0"
 serde = {version = "1.0", features=["derive"]}
 serde_json = "1.0"
 base64 = "0.13"
@@ -20,6 +19,7 @@ openssl = "0.10"
 tokio = { version = "1.0", features = [ "time", "fs" ] }
 tracing = "0.1"
 tracing-futures = "0.2"
+thiserror = "1.0.24"
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["rt-multi-thread", "macros"] }

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -3,10 +3,10 @@ use acme2::AccountBuilder;
 use acme2::AuthorizationStatus;
 use acme2::ChallengeStatus;
 use acme2::DirectoryBuilder;
+use acme2::Error;
 use acme2::OrderBuilder;
 use acme2::OrderStatus;
 use acme2::CSR;
-use anyhow::Error;
 use std::time::Duration;
 
 const LETS_ENCRYPT_URL: &str = "https://acme-v02.api.letsencrypt.org/directory";

--- a/src/account.rs
+++ b/src/account.rs
@@ -1,6 +1,6 @@
 use crate::directory::Directory;
+use crate::error::*;
 use crate::helpers::*;
-use anyhow::Error;
 use openssl::pkey::PKey;
 use openssl::pkey::Private;
 use serde::Deserialize;
@@ -150,13 +150,15 @@ impl AccountBuilder {
     let res: Result<Account, Error> = res.into();
     let mut acc = res?;
 
-    let private_key_id = headers
-      .get(reqwest::header::LOCATION)
-      .ok_or_else(|| {
-        anyhow::anyhow!("mandatory location header in newAccount not present")
-      })?
-      .to_str()?
-      .to_string();
+    let private_key_id = map_transport_err(
+      headers
+        .get(reqwest::header::LOCATION)
+        .ok_or_else(|| {
+          transport_err("mandatory location header in newAccount not present")
+        })?
+        .to_str(),
+    )?
+    .to_string();
     Span::current().record("private_key_id", &field::display(&private_key_id));
 
     acc.directory = Some(self.directory.clone());

--- a/src/authorization.rs
+++ b/src/authorization.rs
@@ -1,9 +1,9 @@
 use crate::account::Account;
+use crate::error::*;
 use crate::helpers::Identifier;
 use crate::helpers::*;
 use crate::jws::Jwk;
 use crate::order::Order;
-use anyhow::Error;
 use openssl::hash::hash;
 use openssl::hash::MessageDigest;
 use serde::Deserialize;
@@ -92,7 +92,7 @@ pub struct Challenge {
 
   /// Error that occurred while the server was validating the
   /// challenge, if any.
-  pub error: Option<AcmeError>,
+  pub error: Option<ServerError>,
 
   /// A random value that uniquely identifies the challenge.
   pub token: Option<String>,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,79 @@
+use serde::Deserialize;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+  #[error("validation error: {0}")]
+  Validation(&'static str),
+
+  #[error(transparent)]
+  Server(#[from] ServerError),
+
+  #[error(transparent)]
+  Transport(Box<dyn std::error::Error>),
+
+  #[error(transparent)]
+  Other(Box<dyn std::error::Error>),
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("transport error: {0}")]
+pub struct TransportError(&'static str);
+
+pub fn transport_err(msg: &'static str) -> Error {
+  Error::Transport(Box::new(TransportError(msg)))
+}
+
+pub fn map_transport_err<T, E: std::error::Error + 'static>(
+  res: Result<T, E>,
+) -> Result<T, Error> {
+  res.map_err(|err| Error::Transport(Box::new(err)))
+}
+
+impl From<reqwest::Error> for Error {
+  fn from(err: reqwest::Error) -> Self {
+    Self::Transport(Box::new(err))
+  }
+}
+
+impl From<serde_json::Error> for Error {
+  fn from(err: serde_json::Error) -> Self {
+    Self::Transport(Box::new(err))
+  }
+}
+
+impl From<openssl::error::ErrorStack> for Error {
+  fn from(err: openssl::error::ErrorStack) -> Self {
+    Self::Other(Box::new(err))
+  }
+}
+
+/// The result of an operation that can return a [`ServerError`].
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", untagged)]
+pub enum ServerResult<T> {
+  Ok(T),
+  Err(ServerError),
+}
+
+impl<T> Into<Result<T, Error>> for ServerResult<T> {
+  fn into(self) -> Result<T, Error> {
+    match self {
+      ServerResult::Ok(t) => Ok(t),
+      ServerResult::Err(err) => Err(err.into()),
+    }
+  }
+}
+/// This is an error as returned by the ACME server.
+#[derive(Deserialize, Debug, Clone, thiserror::Error)]
+#[serde(rename_all = "camelCase")]
+#[error("ServerError({}): {}: {}", r#type.clone().unwrap_or_default(), title.clone().unwrap_or_default(), detail.clone().unwrap_or_default())]
+pub struct ServerError {
+  /// The type of this error.
+  pub r#type: Option<String>,
+  /// The human readable title of this error.
+  pub title: Option<String>,
+  /// The status code of this error.
+  pub status: Option<u16>,
+  /// The human readable extra description for this error.
+  pub detail: Option<String>,
+}

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,4 +1,4 @@
-use anyhow::Error;
+use crate::error::*;
 use openssl::pkey::PKey;
 use openssl::pkey::Private;
 use openssl::rsa::Rsa;
@@ -16,58 +16,13 @@ pub struct Identifier {
   pub value: String,
 }
 
-/// This is an error as returned by the ACME server.
-#[derive(Deserialize, Debug, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct AcmeError {
-  /// The type of this error.
-  pub r#type: Option<String>,
-  /// The human readable title of this error.
-  pub title: Option<String>,
-  /// The status code of this error.
-  pub status: Option<u16>,
-  /// The human readable extra description for this error.
-  pub detail: Option<String>,
-}
-
-impl std::error::Error for AcmeError {}
-
-impl std::fmt::Display for AcmeError {
-  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    write!(
-      f,
-      "AcmeError({}): {}: {}",
-      self.r#type.clone().unwrap_or_default(),
-      self.title.clone().unwrap_or_default(),
-      self.detail.clone().unwrap_or_default()
-    )
-  }
-}
-
-/// The result of an operation that can return an [`AcmeError`].
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase", untagged)]
-pub enum AcmeResult<T> {
-  Ok(T),
-  Err(AcmeError),
-}
-
-impl<T> Into<Result<T, Error>> for AcmeResult<T> {
-  fn into(self) -> Result<T, Error> {
-    match self {
-      AcmeResult::Ok(t) => Ok(t),
-      AcmeResult::Err(err) => Err(err.into()),
-    }
-  }
-}
-
 pub(crate) fn b64(data: &[u8]) -> String {
   base64::encode_config(data, ::base64::URL_SAFE_NO_PAD)
 }
 
 /// Generate a new RSA private key using the specified size,
 /// using the system random.
-pub fn gen_rsa_private_key(bits: u32) -> Result<PKey<Private>, anyhow::Error> {
+pub fn gen_rsa_private_key(bits: u32) -> Result<PKey<Private>, Error> {
   let rsa = Rsa::generate(bits)?;
   let key = PKey::from_rsa(rsa)?;
   Ok(key)

--- a/src/jws.rs
+++ b/src/jws.rs
@@ -1,3 +1,4 @@
+use crate::error::*;
 use crate::helpers::*;
 use openssl::hash::MessageDigest;
 use openssl::pkey::PKey;
@@ -41,7 +42,7 @@ pub(crate) fn jws(
   payload: &str,
   pkey: &PKey<Private>,
   pkey_id: Option<String>,
-) -> Result<String, anyhow::Error> {
+) -> Result<String, Error> {
   let payload_b64 = b64(&payload.as_bytes());
 
   let mut header = JwsHeader {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@
 //! use acme2::OrderBuilder;
 //! use acme2::OrderStatus;
 //! use acme2::CSR;
-//! use anyhow::Error;
+//! use acme2::Error;
 //! use std::time::Duration;
 //!
 //! const LETS_ENCRYPT_URL: &'static str =
@@ -111,6 +111,7 @@
 mod account;
 mod authorization;
 mod directory;
+mod error;
 mod helpers;
 mod jws;
 mod order;
@@ -118,8 +119,10 @@ mod order;
 pub use account::*;
 pub use authorization::*;
 pub use directory::*;
+pub use error::Error;
+pub use error::ServerError;
+pub use error::TransportError;
 pub use helpers::gen_rsa_private_key;
-pub use helpers::AcmeError;
 pub use helpers::Identifier;
 pub use openssl;
 pub use order::*;


### PR DESCRIPTION
Use a strucuted error ﻿type instead of anyhow. This should help with handling
server errors more gracefully, and adding timeouts to the wait calls in the
future.
